### PR TITLE
Add gcc, python devel and pip to openshift-nginx

### DIFF
--- a/base/openshift-nginx/Dockerfile
+++ b/base/openshift-nginx/Dockerfile
@@ -7,7 +7,7 @@ ENV FABRIC8_USER_NAME=fabric8
 ADD root /
 
 RUN yum install --setopt=tsflags=nodocs -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    yum -y install --setopt=tsflags=nodocs nginx gettext && \
+    yum -y install --setopt=tsflags=nodocs nginx gettext python-pip python-devel gcc && \
     yum clean all && \
     rm -f /usr/share/nginx/html/* && \
     useradd --no-create-home -s /bin/bash ${FABRIC8_USER_NAME} && \


### PR DESCRIPTION
It's required by:
https://github.com/openshiftio/status-api/blob/master/Dockerfile

It also adds python-devel and python-pip