### PR TITLE
Remove reference to missing script

### DIFF
--- a/base/openshift-nginx/root/run.sh
+++ b/base/openshift-nginx/root/run.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-/template.sh /usr/share/nginx/html
-VARS='$PROXY_PASS_URL' /template.sh /etc/nginx/nginx.conf
 echo "----"
 id
 echo "----"


### PR DESCRIPTION
This script has been inherited from:
https://github.com/fabric8-ui/fabric8-ui-openshift-nginx/tree/master/root

But it should have been inherited from:
https://github.com/kbsingh/openshift-nginx/blob/master/root/run.sh