### PR TITLE
Fix generate-index.py after applying quay.io

### DIFF
--- a/generate-index.py
+++ b/generate-index.py
@@ -22,9 +22,9 @@ for filename in glob.glob("base/*/Dockerfile"):
 
     job = {'image_name': image_name, 'branch_name': 'master'}
 
-    if docker_from_registry == "prod.registry.devshift.net":
+    if docker_from_registry == "quay.io":
         kind = "downstream-rhel"
-        job['parent_job'] = 'rhel-%s-master' % (docker_from_image_name,)
+        job['parent_job'] = '%s-master' % (docker_from_image_name,)
     else:
         kind = "base-rhel"
 


### PR DESCRIPTION
This is an output example

```yaml
- job:
    name: 'EL-Dockerfiles-pr-check'
    properties:
        - github:
            url: https://github.com/rhdt/EL-Dockerfiles
    display-name: 'EL-Dockerfiles-pr-check'
    scm:
        - git:
            url: https://github.com/rhdt/EL-Dockerfiles.git
            # credentials-id: ""
            skip-tag: True
            refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
            branches:
                - '${ghprbActualCommit}'
    triggers:
      - github-pull-request:
          status-context: "rhel ci PR build"
          admin-list:
              - jmelis
              - riuvshin
              - kbsingh
              - rh-devtools-bot
          cron: '* * * * *'
          github-hooks: false
          permit-all: false
          trigger-phrase: '.*\[test\].*'
          allow-whitelist-orgs-as-admins: true
          status-context: "rhel ci PR build"
    builders:
      - shell: ./pr_check.sh

- job_defaults: &job_defaults
    name: 'defaults'
    defaults: global
    project-type: freestyle
    display-name: 'rhel-{image_name}-{branch_name}'
    description: 'Do not edit this job through the web!'
    concurrent: false
    scm:
      - git:
          url: https://github.com/rhdt/EL-Dockerfiles.git
          shallow_clone: true
          branches:
            - '{branch_name}'
          sparse-checkout:
            paths:
              - 'base/{image_name}'
          included-regions:
            - 'base/{image_name}/.*'
    builders:
      - shell: |
          #!/bin/bash
          set -ex
          echo 'Building {image_name} image'
          cd base/{image_name}/

          docker build --pull \
            -t push.registry.devshift.net/osio-prod/base/{image_name}:latest \
            -t quay.io/openshiftio/rhel-base-{image_name}:latest \
            .

          docker push push.registry.devshift.net/osio-prod/base/{image_name}:latest
          docker push quay.io/openshiftio/rhel-base-{image_name}:latest

- job-template:
    name: 'rhel-{image_name}-{branch_name}'
    id: 'base-rhel'
    triggers:
      - timed: "@weekly"
      - pollscm:
          cron: "H/3 * * * *"
    <<: *job_defaults

- job-template:
    name: 'rhel-{image_name}-{branch_name}'
    id: 'downstream-rhel'
    triggers:
      - pollscm:
          cron: "H/3 * * * *"
      - reverse:
          jobs:
            - '{parent_job}'
          result: 'success'
    <<: *job_defaults

- project:
    jobs:
    - base-rhel:
        branch_name: master
        image_name: fabric8-analytics-data-model
    - downstream-rhel:
        branch_name: master
        image_name: fabric8-analytics-jobs
        parent_job: rhel-base-pcp-master
    - base-rhel:
        branch_name: master
        image_name: fabric8-analytics-pgbouncer
    - base-rhel:
        branch_name: master
        image_name: fabric8-analytics-scaler
    - downstream-rhel:
        branch_name: master
        image_name: fabric8-analytics-server
        parent_job: rhel-base-pcp-master
    - base-rhel:
        branch_name: master
        image_name: fabric8-analytics-stack-analysis-base
    - base-rhel:
        branch_name: master
        image_name: fabric8-analytics-stack-report-ui
    - downstream-rhel:
        branch_name: master
        image_name: fabric8-analytics-worker
        parent_job: rhel-base-pcp-master
    - downstream-rhel:
        branch_name: master
        image_name: fabric8-openshift-nginx
        parent_job: rhel-base-openshift-nginx-master
    - base-rhel:
        branch_name: master
        image_name: golang
    - base-rhel:
        branch_name: master
        image_name: httpd
    - downstream-rhel:
        branch_name: master
        image_name: jboss-jdk-8
        parent_job: rhel-base-pcp-master
    - downstream-rhel:
        branch_name: master
        image_name: mattermost
        parent_job: rhel-base-pcp-master
    - downstream-rhel:
        branch_name: master
        image_name: nginx-redirector
        parent_job: rhel-base-openshift-nginx-master
    - downstream-rhel:
        branch_name: master
        image_name: nodejs
        parent_job: rhel-base-pcp-master
    - base-rhel:
        branch_name: master
        image_name: openshift-nginx
    - downstream-rhel:
        branch_name: master
        image_name: osd-loggers
        parent_job: rhel-base-pcp-master
    - base-rhel:
        branch_name: master
        image_name: pcp
    - downstream-rhel:
        branch_name: master
        image_name: python2
        parent_job: rhel-base-pcp-master
    - base-rhel:
        branch_name: master
        image_name: python3
    - downstream-rhel:
        branch_name: master
        image_name: rh-che
        parent_job: rhel-base-jboss-jdk-8-master
    - base-rhel:
        branch_name: master
        image_name: rhel
    - downstream-rhel:
        branch_name: master
        image_name: status-api
        parent_job: rhel-base-openshift-nginx-master
    - downstream-rhel:
        branch_name: master
        image_name: pcp-tools
        parent_job: rhel-base-pcp-master
    name: rhel-build
```