### PR TITLE
Use no-cache for builds when code changes

### DIFF
--- a/build_push.sh
+++ b/build_push.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ex
+
+IMAGE_NAME="$1"
+
+echo "Building ${IMAGE_NAME} image"
+
+cd base/${IMAGE_NAME}/
+
+if [[ "$GIT_COMMIT" != "$GIT_PREVIOUS_COMMIT" ]]; then
+  NO_CACHE_CMD="--no-cache"
+fi
+
+DEVSHIFT_TAG="push.registry.devshift.net/osio-prod/base/${IMAGE_NAME}:latest"
+QUAY_TAG="quay.io/openshiftio/rhel-base-${IMAGE_NAME}:latest"
+
+docker build --pull "${NO_CACHE_CMD}" \
+  -t "${DEVSHIFT_TAG}" \
+  -t "${QUAY_TAG}" \
+  .
+
+docker push "${DEVSHIFT_TAG}"
+docker push "${QUAY_TAG}"

--- a/rhel-index.yaml.head
+++ b/rhel-index.yaml.head
@@ -48,20 +48,7 @@
           included-regions:
             - 'base/{image_name}/.*'
     builders:
-      - shell: |
-          #!/bin/bash
-          set -ex
-          echo 'Building {image_name} image'
-          cd base/{image_name}/
-
-          docker build --pull \
-            -t push.registry.devshift.net/osio-prod/base/{image_name}:latest \
-            -t quay.io/openshiftio/rhel-base-{image_name}:latest \
-            .
-
-          docker push push.registry.devshift.net/osio-prod/base/{image_name}:latest
-          docker push quay.io/openshiftio/rhel-base-{image_name}:latest
-
+      - shell: ./build_push.sh {image_name}
 - job-template:
     name: 'rhel-{image_name}-{branch_name}'
     id: 'base-rhel'


### PR DESCRIPTION
New commit: build with --no-cache

* GIT_PREVIOUS_COMMIT is defined
* GIT_PREVIOUS_COMMIT != GIT_COMMIT

Timer: regular build (with cache)

* GIT_PREVIOUS_COMMIT is defined
* GIT_PREVIOUS_COMMIT == GIT_COMMIT

Manual: build with --no-cache

* GIT_PREVIOUS_COMMIT is not defined

This works the same for downstream jobs