### PR TITLE
Run yum update and confirm packages are installed

### DIFF
--- a/base/pcp/Dockerfile
+++ b/base/pcp/Dockerfile
@@ -9,7 +9,9 @@ ENV PCP_DIRS="/etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp"
 
 COPY pcp.repo /etc/yum.repos.d/pcp.repo
 
-RUN yum -y update && yum install -y $PCP_PACKAGES && yum clean all && \
+RUN yum -y update && \
+    yum install -y $PCP_PACKAGES && \
+    yum clean all && \
     mkdir -p $PCP_DIRS  && \
     chgrp -R root $PCP_DIRS && \
     chmod -R g+rwX $PCP_DIRS

--- a/base/pcp/Dockerfile
+++ b/base/pcp/Dockerfile
@@ -1,10 +1,19 @@
 FROM registry.access.redhat.com/rhel7
 ENV LANG=en_US.utf8
 
+ENV PCP_PACKAGES="pcp pcp-pmda-prometheus pcp-manager pcp-debuginfo \
+                    pcp-export-pcp2zabbix pcp-system-tools pcp-webapi \
+                    pcp-webapps pcp-pmda-postgresql"
+
+ENV PCP_DIRS="/etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp"
+
 COPY pcp.repo /etc/yum.repos.d/pcp.repo
-RUN yum install -y pcp pcp-pmda-prometheus pcp-manager pcp-debuginfo \
-                   pcp-export-pcp2zabbix pcp-system-tools pcp-webapi \
-                   pcp-webapps pcp-pmda-postgresql && yum clean all && \
-    mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp  && \
-    chgrp -R root /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
-    chmod -R g+rwX /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
+
+RUN yum -y update && yum install -y $PCP_PACKAGES && yum clean all && \
+    mkdir -p $PCP_DIRS  && \
+    chgrp -R root $PCP_DIRS && \
+    chmod -R g+rwX $PCP_DIRS
+
+# check that the packages have been installed, yum install may return 0 even
+# if a package was not successfully installed
+RUN rpm --query --queryformat "" $PCP_PACKAGES


### PR DESCRIPTION
After the last build of of pcp there are some failed rpm scripts messages in the [logs](https://zabbix.devshift.net:9444/job/rhel-pcp-master/10/console):

    warning: %post(pcp-webapi-4.1.0-0.201805281909.git68ab4b18.el7.x86_64) scriptlet failed, exit status 1
    Non-fatal POSTIN scriptlet failure in rpm package pcp-webapi-4.1.0-0.201805281909.git68ab4b18.el7.x86_64
     Installing : pcp-manager-4.1.0-0.201805281909.git68ab4b18.el7.x86_6    97/100 
    warning: %post(pcp-manager-4.1.0-0.201805281909.git68ab4b18.el7.x86_64) scriptlet failed, exit status 1
    Non-fatal POSTIN scriptlet failure in rpm package pcp-manager-4.1.0-0.201805281909.git68ab4b18.el7.x86_64
     Installing : pcp-pmda-postgresql-4.1.0-0.201805281909.git68ab4b18.e    98/100 

The packages are indeed there:

    $ docker run --rm -ti quay.io/openshiftio/rhel-base-pcp:latest
    [root@0df265178bbc /]# rpm -q --queryformat "" pcp pcp-pmda-prometheus pcp-manager pcp-debuginfo \
    >                    pcp-export-pcp2zabbix pcp-system-tools pcp-webapi \
    >                    pcp-webapps pcp-pmda-postgresql

Since yum install may return 0 even if a package was not installed there is a `rpm --query` statement at the end. I think a good practice would be to do this ALWAYS after a yum install, in absolutely every Dockerfile.

The other problem is that a few downstream jobs have failed:

- rhel-pcp-tools-master-downstream
- rhel-fabric8-analytics-worker-master-downstream
- rhel-fabric8-analytics-jobs-master-downstream

As @pbergene has suggested, this may be to a missing `yum update`, that's why this is included in this PR.