### PR TITLE
fix PR checks

### DIFF
--- a/base/nodejs-10-java-1.8/Dockerfile
+++ b/base/nodejs-10-java-1.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhoar-nodejs/nodejs-10:latest
+FROM registry.access.redhat.com/rhoar-nodejs/nodejs-10
 
 USER root
 RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel


### PR DESCRIPTION
remove latest tags because base image is not build in this repo.

currently all PR checks failing because of this https://github.com/rhdt/EL-Dockerfiles/blob/master/pr_check.sh#L10

for base images we are not defining tag latest like here: https://github.com/rhdt/EL-Dockerfiles/blob/master/base/pcp/Dockerfile#L1