### PR TITLE
Python3.6 fixes

### DIFF
--- a/base/fabric8-analytics-worker/hack/install_deps_rpm.sh
+++ b/base/fabric8-analytics-worker/hack/install_deps_rpm.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/sh -e
 
 # Required by Dockerfile or any built-time script in hack/
-BUILD="python36-pip python3-pip wget which"
+BUILD="python36-pip python2-pip wget which"
 
 # - We need postgresql-devel and python3-devel for psycopg2 listed in f8a_worker/requirements.txt
 # - We cannot use requests from PyPI since it does not allow us to use own certificates

--- a/base/fabric8-analytics-worker/hack/install_deps_rpm.sh
+++ b/base/fabric8-analytics-worker/hack/install_deps_rpm.sh
@@ -21,7 +21,7 @@ PROCESS_PY='git unzip zip tar file findutils npm'
 DIGESTER='ssdeep'
 
 # mercator-go
-MERCATOR="mercator-1-27.el7.x86_64"
+MERCATOR="mercator-1-33.el7.x86_64"
 
 GOLANG_SUPPORT="golang"
 


### PR DESCRIPTION
* we need pip for Python 2, it was accidentally upgraded to 3 during Python 3.6 migration
* we want the latest Mercator package which supports Python 3.6