### PR TITLE
Add Python3-dev for updating dependencies requirements

### DIFF
--- a/base/python3/Dockerfile
+++ b/base/python3/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/rhel7
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &&\
-    yum install -y gcc gcc-c++ git python36-pip python36-requests httpd httpd-devel python36-devel &&\
+    yum install -y gcc gcc-c++ git python36-pip python36-requests httpd httpd-devel python3-dev python36-devel &&\
     yum install -y redhat-rpm-config libffi-devel openssl-devel python36-setuptools &&\
     yum clean all


### PR DESCRIPTION
Adding python3-dev, so that Cython and other python packages requirements get satisfied. 