### PR TITLE
Enable rhel-7-server-optional-rpms repo

### DIFF
--- a/base/python3/Dockerfile
+++ b/base/python3/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/rhel7
 
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &&\
+RUN yum-config-manager --enable rhel-7-server-optional-rpms &&\
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &&\
     yum install -y gcc gcc-c++ git python36-pip python36-requests httpd httpd-devel python36-devel &&\
     yum install -y redhat-rpm-config libffi-devel openssl-devel python36-setuptools &&\
     yum clean all


### PR DESCRIPTION
This PR is based on the discussion from https://github.com/rhdt/EL-Dockerfiles/pull/83.