### PR TITLE
Updating Hosted Che RHEL image to jdk 11

### DIFF
--- a/base/rh-che/Dockerfile
+++ b/base/rh-che/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshiftio/rhel-base-jboss-jdk-8:latest
+FROM quay.io/openshiftio/rhel-base-jboss-jdk-11:latest
 
 # The following lines are needed to set the correct locale after `yum update`
 # c.f. https://github.com/CentOS/sig-cloud-instance-images/issues/71


### PR DESCRIPTION
Updating Hosted Che RHEL image to jdk 11 - required for https://github.com/redhat-developer/rh-che/pull/1909